### PR TITLE
Move filtering into SQL query and out of the LakeRepo

### DIFF
--- a/app/src/main/java/com/example/shorebuddy/adapters/LakeListAdapter.java
+++ b/app/src/main/java/com/example/shorebuddy/adapters/LakeListAdapter.java
@@ -35,7 +35,7 @@ public class LakeListAdapter extends RecyclerView.Adapter<LakeListAdapter.LakeVi
     private final OnLakeListener onLakeListener;
     private List<Lake> lakes;
 
-        public LakeListAdapter(Context context, OnLakeListener onLakeListener) {
+    public LakeListAdapter(Context context, OnLakeListener onLakeListener) {
         inflater = LayoutInflater.from(context);
         this.onLakeListener = onLakeListener;
     }
@@ -69,9 +69,6 @@ public class LakeListAdapter extends RecyclerView.Adapter<LakeListAdapter.LakeVi
         else return 0;
     }
 
-    public void addLakeList(List<Lake> lakes){
-            this.lakes=lakes;
-    }
     public interface OnLakeListener {
         void onLakeSelected(Lake lake);
     }

--- a/app/src/main/java/com/example/shorebuddy/data/ShoreBuddyDatabase.java
+++ b/app/src/main/java/com/example/shorebuddy/data/ShoreBuddyDatabase.java
@@ -2,15 +2,11 @@ package com.example.shorebuddy.data;
 
 import android.content.Context;
 import android.util.Log;
-import androidx.annotation.NonNull;
 import androidx.room.Database;
-import androidx.room.DatabaseConfiguration;
-import androidx.room.InvalidationTracker;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
-import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 import com.example.shorebuddy.R;
 import com.example.shorebuddy.data.lakes.Lake;
@@ -89,22 +85,5 @@ public abstract class ShoreBuddyDatabase extends RoomDatabase {
                 lakeDao.insertAll(lakes);
             });
         }
-
     };
-    @NonNull
-    @Override
-    protected SupportSQLiteOpenHelper createOpenHelper(DatabaseConfiguration config) {
-        return null;
-    }
-
-    @NonNull
-    @Override
-    protected InvalidationTracker createInvalidationTracker() {
-        return null;
-    }
-
-    @Override
-    public void clearAllTables() {
-
-    }
 }

--- a/app/src/main/java/com/example/shorebuddy/data/lakes/DefaultLakeRepository.java
+++ b/app/src/main/java/com/example/shorebuddy/data/lakes/DefaultLakeRepository.java
@@ -3,18 +3,14 @@ package com.example.shorebuddy.data.lakes;
 import android.app.Application;
 
 import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MutableLiveData;
 
 import com.example.shorebuddy.data.ShoreBuddyDatabase;
 import com.example.shorebuddy.utilities.SearchQuery;
 import java.util.List;
-import java.util.Objects;
-import java.util.Vector;
 
 public class DefaultLakeRepository implements LakeRepository {
 
     private LakeDao lakeDao;
-    private MutableLiveData<List<Lake>> filteredLakes = new MutableLiveData<>();
     private LiveData<List<Lake>> allLakes;
 
     public DefaultLakeRepository(Application application){
@@ -35,13 +31,6 @@ public class DefaultLakeRepository implements LakeRepository {
 
     @Override
     public LiveData<List<Lake>> getFilteredLakes(SearchQuery query) {
-        Vector<Lake> vec = new Vector<>();
-        for (Lake lake: Objects.requireNonNull(this.allLakes.getValue())) {
-            if (lake.name.toLowerCase().contains(query.getRawString().toLowerCase())) {
-                vec.add(lake);
-            }
-        }
-        filteredLakes.setValue(vec);
-        return filteredLakes;
+        return lakeDao.getFilteredLakes(query.getQuery());
     }
 }

--- a/app/src/main/java/com/example/shorebuddy/data/lakes/LakeDao.java
+++ b/app/src/main/java/com/example/shorebuddy/data/lakes/LakeDao.java
@@ -27,4 +27,7 @@ public interface LakeDao {
     @Query("DELETE FROM lake_table")
     void removeAll();
 
+    @Query("SELECT * FROM lake_table WHERE name LIKE :query")
+    LiveData<List<Lake>> getFilteredLakes(String query);
+
 }

--- a/app/src/main/java/com/example/shorebuddy/viewmodels/MainViewModel.java
+++ b/app/src/main/java/com/example/shorebuddy/viewmodels/MainViewModel.java
@@ -18,7 +18,6 @@ import com.example.shorebuddy.data.weather.WeatherRepository;
 import com.example.shorebuddy.utilities.SearchQuery;
 import com.example.shorebuddy.utilities.UpdateManager;
 
-
 import com.example.shorebuddy.data.solunar.SolunarRepository;
 
 import org.json.JSONException;

--- a/app/src/main/java/com/example/shorebuddy/views/LakeSelectFragment.java
+++ b/app/src/main/java/com/example/shorebuddy/views/LakeSelectFragment.java
@@ -3,9 +3,7 @@ package com.example.shorebuddy.views;
 import android.app.Activity;
 import android.os.Bundle;
 
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavDirections;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -21,7 +19,6 @@ import com.example.shorebuddy.adapters.LakeListAdapter;
 import com.example.shorebuddy.data.lakes.Lake;
 import com.example.shorebuddy.viewmodels.MainViewModel;
 
-import java.util.List;
 import java.util.Objects;
 
 import static androidx.navigation.fragment.NavHostFragment.findNavController;
@@ -54,12 +51,7 @@ public class LakeSelectFragment extends Fragment implements LakeListAdapter.OnLa
         lakesRecyclerView.setAdapter(lakesAdapter);
         lakesRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
         assert activity != null;
-        mainViewModel.getAllLakes().observe(getViewLifecycleOwner(), new Observer<List<Lake>>() {
-            @Override
-            public void onChanged(@Nullable List<Lake> lakes) {
-            lakesAdapter.addLakeList(lakes);
-            }
-        });
+        mainViewModel.getAllLakes().observe(getViewLifecycleOwner(), lakesAdapter::setLakes);
         mainViewModel.setSearchQuery("");
         mainViewModel.getFilteredLakes().observe(getViewLifecycleOwner(), lakesAdapter::setLakes);
 

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -23,8 +23,9 @@
 
         <TextView
             android:id="@+id/current_lake_text"
-            android:layout_width="170dp"
-            android:layout_height="188dp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:paddingHorizontal="8dp"
             app:layout_constraintBottom_toTopOf="@+id/weather_guideline"
             app:layout_constraintEnd_toStartOf="@id/current_weather_text"
             app:layout_constraintHorizontal_weight=".8"
@@ -34,8 +35,8 @@
 
         <com.example.shorebuddy.views.WeatherView
             android:id="@+id/current_weather_text"
-            android:layout_width="238dp"
-            android:layout_height="368dp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/weather_guideline"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_weight="1"
@@ -69,11 +70,12 @@
 
         <TextView
             android:id="@+id/fishList_Text"
-            android:layout_width="166dp"
-            android:layout_height="172dp"
-            app:layout_constraintBottom_toTopOf="@+id/weather_guideline"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:paddingHorizontal="8dp"
+            app:layout_constraintTop_toBottomOf="@+id/weather_guideline"
             app:layout_constraintEnd_toStartOf="@+id/current_weather_text"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/current_lake_text" />
+            app:layout_constraintBottom_toTopOf="@+id/last_updated_weather_text" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
The LakeRepository, and our repositories in general are responsible for deciding which data source a piece of data comes from. However it is not responsible for running the filtering algorithms. To keep with SOLID principles this pull request moves the filtering responsibility into the LakeDAO which uses a SQL query to only pull the filtered data from the database. 

This commit also fixes some layout constraints that were broken. android:layout_width and android:layout_height should almost never be a concrete value. Rather they should be set to match the constraints provided to the view (0dp) or match_parent, or wrap_content. This allows the view to scale gracefully on different sized displays.