### PR TITLE
Add photo ViewPager to catch entry page. Move current lake select to …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,8 +26,7 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/map_key" />
         <activity
-            android:name=".MainActivity"
-            android:windowSoftInputMode="adjustPan">
+            android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/shorebuddy/MainActivity.java
+++ b/app/src/main/java/com/example/shorebuddy/MainActivity.java
@@ -5,10 +5,12 @@ import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.NavigationUI;
 
 import android.os.Bundle;
+import android.view.View;
 
+import com.example.shorebuddy.utilities.BottomViewToggle;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements BottomViewToggle {
     BottomNavigationView bottomNavigationView;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -21,5 +23,18 @@ public class MainActivity extends AppCompatActivity {
         bottomNavigationView = findViewById(R.id.bottom_navigation);
         NavHostFragment navHostFragment = (NavHostFragment)getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment);
         NavigationUI.setupWithNavController(bottomNavigationView,navHostFragment.getNavController());
+        disableBottomNavigationView();
+    }
+
+    @Override
+    public void disableBottomNavigationView() {
+        bottomNavigationView.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void enableBottomNavigationView() {
+        if (bottomNavigationView.getVisibility() == View.GONE) {
+            bottomNavigationView.setVisibility(View.VISIBLE);
+        }
     }
 }

--- a/app/src/main/java/com/example/shorebuddy/adapters/ImageAdapter.java
+++ b/app/src/main/java/com/example/shorebuddy/adapters/ImageAdapter.java
@@ -25,6 +25,7 @@ public class ImageAdapter extends PagerAdapter {
     }
 
     public void setImagePaths(List<CatchPhoto> imagePaths) {
+        listImagePaths.clear();
         for(CatchPhoto imagePath : imagePaths){
             listImagePaths.add(imagePath.path);
         }

--- a/app/src/main/java/com/example/shorebuddy/data/catches/CatchesDao.java
+++ b/app/src/main/java/com/example/shorebuddy/data/catches/CatchesDao.java
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import androidx.room.Transaction;
 import androidx.room.Update;
@@ -17,7 +18,7 @@ public interface CatchesDao {
     @Insert
     long insert(CatchRecord record);
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     void insert(CatchPhoto photo);
 
     @Update

--- a/app/src/main/java/com/example/shorebuddy/data/catches/DefaultCatchRepository.java
+++ b/app/src/main/java/com/example/shorebuddy/data/catches/DefaultCatchRepository.java
@@ -48,10 +48,10 @@ public class DefaultCatchRepository implements CatchRepository {
     public void updateCatch(CatchRecordWithPhotos recordWithPhotos) {
         ShoreBuddyDatabase.databaseExecutor.execute(() -> {
             catchesDao.update(recordWithPhotos.record);
-//            for (CatchPhoto photo : recordWithPhotos.photos) {
-//                photo.catchRecordUid = recordWithPhotos.record.uid;
-//                catchesDao.insert(photo);
-//            }
+            for (CatchPhoto photo : recordWithPhotos.photos) {
+                photo.catchRecordUid = recordWithPhotos.record.uid;
+                catchesDao.insert(photo);
+            }
         });
     }
 }

--- a/app/src/main/java/com/example/shorebuddy/utilities/BottomViewToggle.java
+++ b/app/src/main/java/com/example/shorebuddy/utilities/BottomViewToggle.java
@@ -1,0 +1,6 @@
+package com.example.shorebuddy.utilities;
+
+public interface BottomViewToggle {
+    void disableBottomNavigationView();
+    void enableBottomNavigationView();
+}

--- a/app/src/main/java/com/example/shorebuddy/viewmodels/CatchEntryViewModel.java
+++ b/app/src/main/java/com/example/shorebuddy/viewmodels/CatchEntryViewModel.java
@@ -23,7 +23,6 @@ import com.example.shorebuddy.utilities.Event;
 import com.example.shorebuddy.viewmodels.LakeSelect.LakeSelectResultViewModel;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -39,6 +38,7 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
     private requestPersist requestPersist;
 
     private MutableLiveData<Event> recordChanged = new MutableLiveData<>(new Event());
+    private MutableLiveData<Event> photosChanged = new MutableLiveData<>(new Event());
     private LiveData<String> dateText = Transformations.map(recordChanged, event -> dateFormat.format(catchRecordWithPhotos.record.timeCaught.getTime()));
     private LiveData<String> timeText = Transformations.map(recordChanged, event -> timeFormat.format(catchRecordWithPhotos.record.timeCaught.getTime()));
     private LiveData<Integer> currentYear = Transformations.map(recordChanged, event -> catchRecordWithPhotos.record.timeCaught.get(Calendar.YEAR));
@@ -51,6 +51,7 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
     private LiveData<String> currentWeight = Transformations.map(recordChanged, event -> Double.toString(catchRecordWithPhotos.record.weight));
     private LiveData<String> currentLength = Transformations.map(recordChanged, event -> Double.toString(catchRecordWithPhotos.record.length));
     private LiveData<String> currentComments = Transformations.map(recordChanged, event -> catchRecordWithPhotos.record.comments);
+    private LiveData<List<CatchPhoto>> currentPhotos = Transformations.map(photosChanged, event -> catchRecordWithPhotos.photos);
     private MutableLiveData<Mode> entryMode = new MutableLiveData<>(Mode.CREATE);
     private LiveData<Integer> modeIcon = Transformations.map(entryMode, mode -> {
         if (mode == Mode.CREATE) {
@@ -80,12 +81,14 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
         entryMode.setValue(Mode.CREATE);
         catchRecordWithPhotos = new CatchRecordWithPhotos();
         recordChanged.setValue(new Event());
+        photosChanged.setValue(new Event());
     }
 
     public void editRecord(CatchRecordWithPhotos record) {
         catchRecordWithPhotos = record;
         entryMode.setValue(Mode.EDIT);
         recordChanged.setValue(new Event());
+        photosChanged.setValue(new Event());
     }
 
     public LiveData<Integer> getModeIcon() {
@@ -125,6 +128,8 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
         return timeText;
     }
 
+    public LiveData<List<CatchPhoto>> getCurrentPhotos() { return currentPhotos; }
+
     public LiveData<List<Fish>> getAllFish() { return fishRepository.getAllFish(); }
 
     public LiveData<String> getLake() {
@@ -152,12 +157,9 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
         this.requestPersist = requestPersist;
     }
 
-    public void addPhoto(ArrayList<String> paths) {
-        CatchPhoto newPhoto;
-        for(String path : paths) {
-            newPhoto = new CatchPhoto(path);
-            catchRecordWithPhotos.photos.add(newPhoto);
-        }
+    public void addPhoto(String path) {
+        catchRecordWithPhotos.photos.add(new CatchPhoto(path));
+        photosChanged.setValue(new Event());
     }
 
     public void setLake(String lake) {
@@ -231,7 +233,7 @@ public class CatchEntryViewModel extends AndroidViewModel implements LakeSelectR
     public void onNothingSelected(AdapterView<?> parent) {}
 
     public interface requestPersist {
-        public void persist();
+        void persist();
     }
 
     public enum CalendarField {

--- a/app/src/main/java/com/example/shorebuddy/views/CatchEntryFragment.java
+++ b/app/src/main/java/com/example/shorebuddy/views/CatchEntryFragment.java
@@ -52,7 +52,6 @@ public class CatchEntryFragment extends Fragment implements CatchEntryViewModel.
     private FragmentCatchEntryBinding binding;
     private static final int CAMERA_REQUEST_CODE = 102;
     private String currentPhotoPath;
-    private ArrayList<String> imagePaths = new ArrayList<>();
 
     public CatchEntryFragment() {}
 
@@ -194,14 +193,7 @@ public class CatchEntryFragment extends Fragment implements CatchEntryViewModel.
 
     private void setCurrentlySelectedLake() {
         MainViewModel mainViewModel = new ViewModelProvider(Objects.requireNonNull(getActivity())).get(MainViewModel.class);
-        String lake;
-        // TODO: REMOVE HIGH PRIORITY, enforce selected lake choice.
-        if (mainViewModel.getCurrentlySelectedLake().getValue() == null) {
-            lake = "Pinecrest Lake";
-        } else {
-            lake = mainViewModel.getCurrentlySelectedLake().getValue().lakeName;
-        }
-        catchEntryViewModel.setLake(lake);
+        catchEntryViewModel.setLake(mainViewModel.getCurrentlySelectedLake().getValue().lakeName);
     }
 
    void takePicture() {dispatchTakePictureIntent();}

--- a/app/src/main/java/com/example/shorebuddy/views/CatchRecordDisplayFragment.java
+++ b/app/src/main/java/com/example/shorebuddy/views/CatchRecordDisplayFragment.java
@@ -20,6 +20,7 @@ import com.example.shorebuddy.adapters.ImageAdapter;
 import com.example.shorebuddy.data.relationships.CatchRecordWithPhotos;
 import com.example.shorebuddy.viewmodels.CatchRecordDisplayViewModel;
 import com.example.shorebuddy.R;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 
 import static androidx.navigation.fragment.NavHostFragment.findNavController;
@@ -55,7 +56,7 @@ public class CatchRecordDisplayFragment extends Fragment {
         catchRecordDisplayViewModel.recordLength.observe(getViewLifecycleOwner(), lengthText::setText);
         TextView commentsText = rootView.findViewById(R.id.comments);
         catchRecordDisplayViewModel.recordComments.observe(getViewLifecycleOwner(), commentsText::setText);
-        Button editButton = rootView.findViewById(R.id.edit_btn);
+        FloatingActionButton editButton = rootView.findViewById(R.id.edit_btn);
         editButton.setOnClickListener(this::onEditClick);
         viewPager = rootView.findViewById(R.id.imageSlider);
         imageAdapter = new ImageAdapter(getContext());

--- a/app/src/main/java/com/example/shorebuddy/views/homepage/HomepageView.java
+++ b/app/src/main/java/com/example/shorebuddy/views/homepage/HomepageView.java
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.shorebuddy.R;
 import com.example.shorebuddy.adapters.HomepageAdapter;
+import com.example.shorebuddy.utilities.BottomViewToggle;
 import com.example.shorebuddy.viewmodels.LakeSelect.LakeSelectResultViewModel;
 import com.example.shorebuddy.viewmodels.MainViewModel;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -42,6 +43,8 @@ public class HomepageView extends Fragment {
         fishWidget = new FishWidget(getContext());
         solunarWidget = new SolunarWidget(getContext());
         weatherWidget = new WeatherWidget(getContext());
+        BottomViewToggle activity = (BottomViewToggle) getActivity();
+        activity.enableBottomNavigationView();
     }
 
     private List<ModuleWidget> getWidgets() {

--- a/app/src/main/java/com/example/shorebuddy/views/homepage/HomepageView.java
+++ b/app/src/main/java/com/example/shorebuddy/views/homepage/HomepageView.java
@@ -10,16 +10,21 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavDirections;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.shorebuddy.R;
 import com.example.shorebuddy.adapters.HomepageAdapter;
+import com.example.shorebuddy.viewmodels.LakeSelect.LakeSelectResultViewModel;
 import com.example.shorebuddy.viewmodels.MainViewModel;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static androidx.navigation.fragment.NavHostFragment.findNavController;
 
 public class HomepageView extends Fragment {
 
@@ -80,6 +85,14 @@ public class HomepageView extends Fragment {
         mainViewModel.getWeatherData().observe(getViewLifecycleOwner(), weather -> {
             weatherWidget.setData(weather);
             adapter.setWidgets(getWidgets());
+        });
+
+        FloatingActionButton selectLakeButton = rootView.findViewById(R.id.selectLakeBtn);
+        selectLakeButton.setOnClickListener((v) -> {
+            LakeSelectResultViewModel lakeViewModel = new ViewModelProvider(getActivity()).get(LakeSelectResultViewModel.class);
+            lakeViewModel.setLakeSelectedCallback(mainViewModel);
+            NavDirections action = HomepageViewDirections.actionHomepageViewToLakeSelectFragment();
+            findNavController(this).navigate(action);
         });
 
         adapter.setWidgets(getWidgets());

--- a/app/src/main/res/icons/weather/drawable/ic_add_a_photo_black_24dp.xml
+++ b/app/src/main/res/icons/weather/drawable/ic_add_a_photo_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,4L3,1h2v3h3v2L5,6v3L3,9L3,6L0,6L0,4h3zM6,10L6,7h3L9,4h7l1.83,2L21,6c1.1,0 2,0.9 2,2v12c0,1.1 -0.9,2 -2,2L5,22c-1.1,0 -2,-0.9 -2,-2L3,10h3zM13,19c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5 -5,2.24 -5,5 2.24,5 5,5zM9.8,14c0,1.77 1.43,3.2 3.2,3.2s3.2,-1.43 3.2,-3.2 -1.43,-3.2 -3.2,-3.2 -3.2,1.43 -3.2,3.2z"/>
+</vector>

--- a/app/src/main/res/icons/weather/drawable/ic_edit_black_24dp.xml
+++ b/app/src/main/res/icons/weather/drawable/ic_edit_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/app/src/main/res/icons/weather/drawable/ic_public_black_24dp.xml
+++ b/app/src/main/res/icons/weather/drawable/ic_public_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,19.93c-3.95,-0.49 -7,-3.85 -7,-7.93 0,-0.62 0.08,-1.21 0.21,-1.79L9,15v1c0,1.1 0.9,2 2,2v1.93zM17.9,17.39c-0.26,-0.81 -1,-1.39 -1.9,-1.39h-1v-3c0,-0.55 -0.45,-1 -1,-1L8,12v-2h2c0.55,0 1,-0.45 1,-1L11,7h2c1.1,0 2,-0.9 2,-2v-0.41c2.93,1.19 5,4.06 5,7.41 0,2.08 -0.8,3.97 -2.1,5.39z"/>
+</vector>

--- a/app/src/main/res/layout/catch_record_display_fragment.xml
+++ b/app/src/main/res/layout/catch_record_display_fragment.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:background="@color/colorWeatherIconBG"
     android:layout_height="match_parent">
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="8dp">
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -146,7 +150,7 @@
         <TextView
             android:id="@+id/comments"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginVertical="8dp"
             android:maxLines="8"
             android:scrollHorizontally="false"
@@ -164,15 +168,16 @@
             app:layout_constraintTop_toBottomOf="@id/comments"
             app:layout_constraintBottom_toBottomOf="parent"/>
 
-        <Button
-            android:id="@+id/edit_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Edit"
-            android:background="@color/colorAccent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imageSlider" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+           </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:id="@+id/edit_btn"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="8dp"
+    android:src="@drawable/ic_edit_black_24dp"
+    android:background="@color/colorAccent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_catch_entry.xml
+++ b/app/src/main/res/layout/fragment_catch_entry.xml
@@ -5,6 +5,9 @@
     <data>
 
     </data>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -14,14 +17,15 @@
             android:layout_height="match_parent"
             android:layout_margin="8dp"
             tools:context=".views.CatchEntryFragment">
-            <Button
+            <ImageButton
                 android:id="@+id/cameraButton"
-                android:text="@string/add_pictures"
+                android:src="@drawable/ic_add_a_photo_black_24dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:padding="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:layout_gravity="center"
-                android:background="@color/colorAccent"
+                android:background="@drawable/rounded_square_white"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toTopOf="@id/fish_entry_title"/>
             <TextView
@@ -170,7 +174,7 @@
             <EditText
                 android:id="@+id/comments_input"
                 android:layout_width="0dp"
-                android:layout_height="50dp"
+                android:layout_height="wrap_content"
                 android:layout_marginVertical="8dp"
                 android:gravity="top|start"
                 android:imeOptions="actionDone"
@@ -178,20 +182,30 @@
                 android:maxLines="8"
                 android:scrollbars="vertical"
                 android:scrollHorizontally="false"
-                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/imageSlider"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/comments_label" />
 
+            <androidx.viewpager.widget.ViewPager
+                android:id="@+id/imageSlider"
+                android:layout_width="match_parent"
+                android:layout_height="300dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/comments_input"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/save_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="60dp"
-                android:src="@drawable/ic_add_black_24dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/save_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:src="@drawable/ic_add_black_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/homepage.xml
+++ b/app/src/main/res/layout/homepage.xml
@@ -4,6 +4,7 @@
     android:layout_height="match_parent"
     android:background="@color/colorPrimaryDark"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".views.homepage.HomepageView">
 
     <androidx.recyclerview.widget.RecyclerView
@@ -12,5 +13,14 @@
         android:id="@+id/homepage_recycler">
 
     </androidx.recyclerview.widget.RecyclerView>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/selectLakeBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_public_black_24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/bottom_navigation_menu.xml
+++ b/app/src/main/res/menu/bottom_navigation_menu.xml
@@ -12,16 +12,6 @@
         android:title="Map"
         app:showAsAction="always" />
     <item
-        android:id="@+id/lakeSelectFragment"
-        android:icon="@drawable/ic_format_list_bulleted"
-        android:title="Lakes"
-        app:showAsAction="always" />
-
-
-    //set android:id = the id of the fragment you want to replace it with by
-    //going to nav_graph adding the fragment page you want to add, and copying the id onto id of
-    item
-    <item
         android:id="@+id/catchEntryFragment"
         android:icon="@drawable/ic_file_upload"
         android:title="@string/catch_str"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -86,7 +86,11 @@
         android:id="@+id/homepageView"
         android:name="com.example.shorebuddy.views.homepage.HomepageView"
         android:label="homepage"
-        tools:layout="@layout/homepage" />
+        tools:layout="@layout/homepage" >
+        <action
+            android:id="@+id/action_homepageView_to_lakeSelectFragment"
+            app:destination="@id/lakeSelectFragment" />
+    </fragment>
     <fragment
         android:id="@+id/catchRecordDisplayFragment"
         android:name="com.example.shorebuddy.views.CatchRecordDisplayFragment"


### PR DESCRIPTION
...homepage.
Unfortunately due to the modular way lake select is set up now, it cannot be called from the main navigation bar at the bottom. I have moved it to the homepage. 

This commit also adds the view pager to the catch entry page so user can view the photos they add as they add them.

We also enforce that a user must select a CurrentlySelectedLake when opening the app by hiding the BottomNavigationView until they have done so. This way they cannot put the app into an corrupted state. 