### PR TITLE
Change title of counties select dialog. Unify filter icon colors.

### DIFF
--- a/app/src/main/java/com/example/shorebuddy/views/select_dialogs/CountySelectDialogFragment.java
+++ b/app/src/main/java/com/example/shorebuddy/views/select_dialogs/CountySelectDialogFragment.java
@@ -5,6 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.example.shorebuddy.R;
 import com.example.shorebuddy.adapters.BasicFilterAdapter;
 
 import java.util.List;
@@ -13,7 +14,9 @@ public class CountySelectDialogFragment extends SelectDialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         dialogSelectResultViewModel.setData(dialogSelectViewModel.getAllCounties());
-        return super.onCreateView(inflater, container, savedInstanceState);
+        View rootView = super.onCreateView(inflater, container, savedInstanceState);
+        binding.titleText.setText(R.string.counties_title);
+        return rootView;
     }
     @Override
     void setupDataObservation(BasicFilterAdapter adapter) {

--- a/app/src/main/java/com/example/shorebuddy/views/select_dialogs/SelectDialogFragment.java
+++ b/app/src/main/java/com/example/shorebuddy/views/select_dialogs/SelectDialogFragment.java
@@ -30,7 +30,7 @@ import java.util.List;
 public abstract class SelectDialogFragment extends DialogFragment {
     DialogSelectResultViewModel dialogSelectResultViewModel;
     DialogSelectViewModel dialogSelectViewModel;
-    private FragmentSelectDialogBinding binding;
+    FragmentSelectDialogBinding binding;
     private SelectionTracker<Long> tracker;
     protected List<String> data;
     private final Long ghostKey = -5L;

--- a/app/src/main/res/icons/weather/drawable/ic_food.xml
+++ b/app/src/main/res/icons/weather/drawable/ic_food.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:viewportHeight="512"
-    android:tint="#F39C9C"
+    android:tint="@color/icon_dark"
     android:viewportWidth="512" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="m0,314.892v10.302h31.671c24.208,0 43.902,-19.694 43.902,-43.902v-10.302h-31.671c-24.208,0 -43.902,19.694 -43.902,43.902z"/>
     <path android:fillColor="#FF000000" android:pathData="m290.482,128.831h78.331v-10.302c0,-24.208 -19.694,-43.902 -43.902,-43.902h-78.331v10.302c0,24.207 19.694,43.902 43.902,43.902z"/>

--- a/app/src/main/res/icons/weather/drawable/ic_place_black_24dp.xml
+++ b/app/src/main/res/icons/weather/drawable/ic_place_black_24dp.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="@color/deleteBackground"
+<vector android:height="24dp" android:tint="@color/icon_dark"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,4 +12,5 @@
     <color name="deleteBackground">#FF5722</color>
     <color name="backgroundGray">#454545</color>
     <color name="foregroundBlue">#0896D8</color>
+    <color name="icon_dark">#6B6B6B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,5 @@
     <string name="county">County:</string>
     <string name="all_lakes">All Lakes</string>
     <string name="all_species">All Species</string>
+    <string name="counties_title">Counties</string>
 </resources>


### PR DESCRIPTION
Before this commit, when selecting counties for filtering the dialog title was species. This fixes that. I also think that the color of the icons for filtering should be uniform. 